### PR TITLE
BUGFIX: Proper RandomizedNPC Saving

### DIFF
--- a/Systems/ArchipelagoSystem.cs
+++ b/Systems/ArchipelagoSystem.cs
@@ -161,7 +161,11 @@ namespace SeldomArchipelago.Systems
             if (randomizedNPCnames.Length > 0)
             {
                 world.randomizedNPCs = (from name in randomizedNPCnames select npcNameToID[name]).ToImmutableHashSet();
-                world.receivedNPCs = new();
+                world.receivedNPCs = session.session.DataStorage[Scope.Slot, "ReceivedNPCs"].To<HashSet<int>>();
+                if (world.receivedNPCs is null)
+                {
+                    world.receivedNPCs = new();
+                }
                 string[] allNPCnames = npcNameToID.Keys.ToArray();
                 var locIDtoNPCname = new Dictionary<long, string>();
                 foreach (string loc in allNPCnames)
@@ -567,6 +571,10 @@ namespace SeldomArchipelago.Systems
             {
                 tag["ApRandomizedNPCs"] = world.randomizedNPCs.ToList();
                 tag["ApReceivedNPCs"] = world.receivedNPCs.ToList();
+                if (session != null)
+                {
+                    session.session.DataStorage[Scope.Slot, "ReceivedNPCs"] = world.receivedNPCs.ToArray();
+                }
             }
         }
 


### PR DESCRIPTION
Recently came to my attention (thanks to a playtester) that `receivedNPCs` was not getting properly loaded on world re-entry. Essentially this is because I never properly implemented its `OnWorldLoad` loading behavior, which `LoadWorldData` automatically defers to when it detects that `OnWorldLoad` has filled in the `randomizedNPCs` field.

This PR implements the loading behavior for `receivedNPCs` in `OnWorldLoad` properly. Let me know if you want anything else looked at. :)