### PR TITLE
Refactor `Tile` into `Tiles`

### DIFF
--- a/Tiles/ArchipelagoGlobalTile.cs
+++ b/Tiles/ArchipelagoGlobalTile.cs
@@ -3,7 +3,7 @@ using Terraria.GameContent.Achievements;
 using Terraria.ID;
 using Terraria.ModLoader;
 
-namespace SeldomArchipelago.Tile
+namespace SeldomArchipelago.Tiles
 {
     public class ArchipelagoGlobalTile : GlobalTile
     {


### PR DESCRIPTION
Changes the folder/namespace of `ArchipelagoGlobalTile`.

This is exclusively so it doesn't run into vanilla collision errors when it compiles on my machine. (I have no idea why you can compile with the `Tile` namespace and I can't. I'd rather not think too much about it.)