### PR TITLE
BUGFIX: Mute achievements on load

### DIFF
--- a/Players/ArchipelagoPlayer.cs
+++ b/Players/ArchipelagoPlayer.cs
@@ -9,6 +9,7 @@ using Terraria.GameContent.Achievements;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
+using Terraria.Audio;
 
 namespace SeldomArchipelago.Players
 {
@@ -48,6 +49,8 @@ namespace SeldomArchipelago.Players
                     if (serCondition.Get<bool>("completed")) condition.Value.Complete();
                 }
             }
+            
+            SoundEngine.StopTrackedSounds();
 
             if (Main.netMode == NetmodeID.MultiplayerClient)
             {


### PR DESCRIPTION
This PR mutes achievements when loading into a world by calling `StopTrackedSounds` right after achievements finish loading.
Implemented early into playtesting for my own branch, and it does the job right every time.