### PR TITLE
BUGFIX: "Begone, Evil!" early activation

### DIFF
--- a/SeldomArchipelago.cs
+++ b/SeldomArchipelago.cs
@@ -910,6 +910,7 @@ namespace SeldomArchipelago
                 _ => null,
             };
 
+            if (name == "Begone, Evil!" && Main.gameMenu) return;  // Hardcoding
             if (name != null) ModContent.GetInstance<ArchipelagoSystem>().QueueLocationClient(name);
             ModContent.GetInstance<ArchipelagoSystem>().Achieved(achievement.Name);
         }


### PR DESCRIPTION
One-liner fix for #16.

Contrary to what that issue posits, this bug affects both Calamity and vanilla worlds, though the former at a far higher rate. There is a non-zero chance that this bug is native to tModLoader.

This is a hardcoded fix. I had considered trying for a dynamic system that differentiated between faulty vs non-faulty achievements that activate while `Main.gameMenu` is true, but to my knowledge, "Begone, Evil!" is the only offender, and it has no other reason to activate while the menu is active rather than worldgen messing with something.

Who knows though, maybe 1.4.5 achievements will start necessitating such a system...