### PR TITLE
BUGFIX: Add case sensitivity to commands

### DIFF
--- a/Command/ApCollectCommand.cs
+++ b/Command/ApCollectCommand.cs
@@ -8,6 +8,7 @@ namespace SeldomArchipelago.Command
         public override string Command => "apcollect";
         public override CommandType Type => CommandType.World;
         public override string Description => "Collects an item without telling the Archipelago server. This is a cheat.";
+        public override bool IsCaseSensitive => true;
 
         public override void Action(CommandCaller caller, string input, string[] args)
         {

--- a/Command/ApCommand.cs
+++ b/Command/ApCommand.cs
@@ -8,6 +8,7 @@ namespace SeldomArchipelago.Command
         public override string Command => "ap";
         public override CommandType Type => CommandType.World;
         public override string Description => "Sends a command to Archipelago";
+        public override bool IsCaseSensitive => true;
 
         public override void Action(CommandCaller caller, string input, string[] args)
         {


### PR DESCRIPTION
Adds case sensitivity to the command arguments of `/ap` and `/apcollect`.

By default, all arguments are converted to lower-case, so the attribute needs to be overridden manually.
While an optional touch for `/ap`, this property is necessary for `/apcollect` to function, since `Collect` is case-sensitive.
Tested by using `/ap` and `/apcollect` to confirm case-sensitivity and proper flag collection.